### PR TITLE
Solution test6

### DIFF
--- a/test6
+++ b/test6
@@ -1,1 +1,33 @@
+use strict;
+use warnings;
 
+# Путь к файлу конфигурации
+my $conf_path = 'D:\Perl\conf.ini';
+
+# Функция для чтения и обработки файла конфигурации
+sub _read_config {
+    my ( $filename ) = @_;
+    open my $fh, '<', $filename or do {
+        print "Не удалось считать конфигурацию с файла: '$filename'";
+        return;
+    };
+    my @lines = <$fh>;
+    close $fh;
+
+    my %config;
+    foreach my $line ( @lines ) {
+        chomp $line; 
+        $line =~ s/\s//g;  #удаляем пробелы
+        next if $line eq "" || $line =~ /^#/;  # проускаем пустые строки и комментарии
+        if ( my ( $key, $value ) = split( /=/, $line, 2 )) {
+            $config{$key} = $value if $key && $value;
+        }
+    }
+    return %config;
+}
+
+# Чтение и вывод конфигурации
+my %conf_hash = _read_config( $conf_path );
+foreach my $key ( keys %conf_hash ) {
+    print "$key => $conf_hash{$key}\n";
+}


### PR DESCRIPTION
Задание №6.
Что мы узнаем:
Преобразование массива в хэш. Регуляные выражения.

Задача:
Модифицировать ф-цию read_conf, чтобы она вернула не массив, а хэш.

Описание:
Глядя на конфиг, само собой напрашивается вернуть хэш, а не массив. Но давайте усложним ситуацию и представим, что конфигурационный файл правил не очень ответственный сотрудник и навставлял туда пробелов, табов, а где-то даже забыл указать ключ или значение. В результате нужно не просто разбить строку user=passwd на ключ и значение и закинуть в хэш, а хорошенько с ней поработать. Тут нам на помощь придут регулярные выражения(РВ). Да, на перный взгляд они будут казаться сложными(Незря по ним есть целая толстая книга). Я их вообще ненавидел, но потом, когда разобрался, понял всю полезность и мощь!
Прочитайте по ним главу в книге и выполните задания.
Если сделали, давайте приступим:
1.Сразу облегчим себе жизнь и с помощью РВ заменим все пробелы на пустоту.
2. Разбив строку на ключ и значение, нужно их проверить на true и если хоть один из них пустой, в хэш эта пара не попадает(ругаться на это не нужно просто пропускаем строку и идем к следующей)
3. Вишенка на торте. Если видели конфигурационный файл crontab(служба запускающая скрипты по расписанию) то могли заметить, что некоторые задания закомментированы символом #. Это значит, что его приостановили на неопределенный срок и crontab его игнорирует. Так вот давайте сделаем это и в нашем конфиге. Если первый симвом #, то пропускаем строку. Делаете это опять же с помощью РВ.
4. После написание ф-ции замените хэш из ф-ции _check_user на хэш полученный из файла.

Подсказка:
Строку можно разбить одной известной командой split, а можно немного покопать и с помощью РВ одним махом проверить формат строки и получить ключ и значение ;)

Полезные привычки:
Обязательно ставьте символ 'm' при поиске по РВ. Например if( $str =~m/\s/ ){} Символ =~ итак вроде указывает на РВ, но perl critic(мы до него дойдем) ругается матом на отсутсвие 'm', ибо так нагляднее и я с ним согласен.